### PR TITLE
Too restrictive access permissions for sink file #37

### DIFF
--- a/bootique-metrics-healthchecks/src/main/java/io/bootique/metrics/health/sink/FileReportSink.java
+++ b/bootique-metrics-healthchecks/src/main/java/io/bootique/metrics/health/sink/FileReportSink.java
@@ -21,9 +21,6 @@ package io.bootique.metrics.health.sink;
 import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
-import java.nio.file.attribute.FileAttribute;
-import java.nio.file.attribute.PosixFilePermissions;
-import java.util.Optional;
 
 /**
  * A {@link ReportSink} writing data to a temp file. Once closed, atomically replaces the target file with the new file.
@@ -37,17 +34,10 @@ public class FileReportSink implements ReportSink {
     private ReportSink tempFileSink;
 
     public FileReportSink(File targetFile) {
-        this(targetFile, null);
-    }
-
-    /**
-     * @since 1.1
-     */
-    public FileReportSink(File targetFile, String permissions) {
         this.targetFile = targetFile;
 
         // write to temp file in the same directory... will replace the target file atomically on close...
-        this.tempFile = createTempFile(targetFile, permissions);
+        this.tempFile = createTempFile(targetFile);
         this.tempFileSink = new WriterReportSink(createWriter(tempFile));
     }
 
@@ -59,22 +49,12 @@ public class FileReportSink implements ReportSink {
         }
     }
 
-    private static File createTempFile(File targetFile, String permissions) {
+    private static File createTempFile(File targetFile) {
         try {
-            return Files.createTempFile(targetFile.getParentFile().toPath(),
-                    targetFile.getName(), ".tmp", permissionsAsFileAttributes(permissions)).toFile();
+            return File.createTempFile(targetFile.getName(), ".tmp", targetFile.getParentFile());
         } catch (IOException e) {
             throw new RuntimeException("Error creating temp file for file " + targetFile, e);
         }
-    }
-
-    private static FileAttribute<?>[] permissionsAsFileAttributes(String permissions) {
-        if (permissions == null) {
-            return new FileAttribute<?>[]{};
-        }
-        return new FileAttribute<?>[]{
-                PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString(permissions))
-        };
     }
 
     @Override

--- a/bootique-metrics-healthchecks/src/main/java/io/bootique/metrics/health/sink/FileReportSinkFactory.java
+++ b/bootique-metrics-healthchecks/src/main/java/io/bootique/metrics/health/sink/FileReportSinkFactory.java
@@ -23,8 +23,6 @@ import io.bootique.annotation.BQConfig;
 import io.bootique.annotation.BQConfigProperty;
 
 import java.io.File;
-import java.nio.file.Path;
-import java.nio.file.attribute.FileAttribute;
 import java.util.Objects;
 import java.util.function.Supplier;
 
@@ -36,7 +34,6 @@ import java.util.function.Supplier;
 public class FileReportSinkFactory implements ReportSinkFactory {
 
     private File file;
-    private String permissions;
 
     private static void setupReportDirectory(File file) {
         File parentDir = file.getParentFile();
@@ -53,7 +50,7 @@ public class FileReportSinkFactory implements ReportSinkFactory {
     @Override
     public Supplier<ReportSink> createReportSyncSupplier() {
         final File file = getFile();
-        return () -> new FileReportSink(file, permissions);
+        return () -> new FileReportSink(file);
     }
 
     private File getFile() {
@@ -65,18 +62,5 @@ public class FileReportSinkFactory implements ReportSinkFactory {
     @BQConfigProperty
     public void setFile(File file) {
         this.file = file;
-    }
-
-    /**
-     * @param permissions Nullable string representation of permissions to set
-     * @see java.nio.file.Files#createTempFile(Path, String, String, FileAttribute[])
-     * @see java.nio.file.attribute.PosixFilePermissions#fromString(String)
-     * @since 1.1
-     */
-    @BQConfigProperty("Desired Unix permissions for the sink file. " +
-            "The format is a 9 character string with 3 sets of 'r', 'w', 'x', '-' symbols. E.g. 'rw-r--r--'." +
-            "Optional. If undefined, permissions will be controlled by 'umask' of the environment.")
-    public void setPermissions(String permissions) {
-        this.permissions = permissions;
     }
 }

--- a/bootique-metrics-healthchecks/src/test/java/io/bootique/metrics/health/sink/FileReportSyncTest.java
+++ b/bootique-metrics-healthchecks/src/test/java/io/bootique/metrics/health/sink/FileReportSyncTest.java
@@ -25,14 +25,10 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.attribute.PosixFilePermission;
 import java.util.Comparator;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.*;
-import static org.junit.Assume.assumeFalse;
 
 public class FileReportSyncTest {
 
@@ -90,63 +86,4 @@ public class FileReportSyncTest {
         sink2.append("1").appendln("2").append("3").close();
         assertReport(report, "12", "3");
     }
-
-    @Test
-    public void testPermissions1() throws IOException {
-
-        assumeFalse(System.getProperty("os.name").toLowerCase().startsWith("win"));
-
-        File dir = newReportDir();
-        File report = new File(dir, "hc1.txt");
-
-        FileReportSink sink1 = new FileReportSink(report, "rw-r--r--");
-        sink1.append("OK");
-        sink1.close();
-
-        assertTrue(report.isFile());
-
-        Set<PosixFilePermission> perms = Files.getPosixFilePermissions(Paths.get(report.getPath()));
-
-        assertTrue(perms.contains(PosixFilePermission.OWNER_READ));
-        assertTrue(perms.contains(PosixFilePermission.OWNER_WRITE));
-        assertFalse(perms.contains(PosixFilePermission.OWNER_EXECUTE));
-
-        assertTrue(perms.contains(PosixFilePermission.GROUP_READ));
-        assertFalse(perms.contains(PosixFilePermission.GROUP_WRITE));
-        assertFalse(perms.contains(PosixFilePermission.GROUP_EXECUTE));
-
-        assertTrue(perms.contains(PosixFilePermission.OTHERS_READ));
-        assertFalse(perms.contains(PosixFilePermission.OTHERS_WRITE));
-        assertFalse(perms.contains(PosixFilePermission.OTHERS_EXECUTE));
-    }
-
-    @Test
-    public void testPermissions2() throws IOException {
-
-        assumeFalse(System.getProperty("os.name").toLowerCase().startsWith("win"));
-
-        File dir = newReportDir();
-        File report = new File(dir, "hc1.txt");
-
-        FileReportSink sink1 = new FileReportSink(report, "rwx--x---");
-        sink1.append("OK");
-        sink1.close();
-
-        assertTrue(report.isFile());
-
-        Set<PosixFilePermission> perms = Files.getPosixFilePermissions(Paths.get(report.getPath()));
-
-        assertTrue(perms.contains(PosixFilePermission.OWNER_READ));
-        assertTrue(perms.contains(PosixFilePermission.OWNER_WRITE));
-        assertTrue(perms.contains(PosixFilePermission.OWNER_EXECUTE));
-
-        assertFalse(perms.contains(PosixFilePermission.GROUP_READ));
-        assertFalse(perms.contains(PosixFilePermission.GROUP_WRITE));
-        assertTrue(perms.contains(PosixFilePermission.GROUP_EXECUTE));
-
-        assertFalse(perms.contains(PosixFilePermission.OTHERS_READ));
-        assertFalse(perms.contains(PosixFilePermission.OTHERS_WRITE));
-        assertFalse(perms.contains(PosixFilePermission.OTHERS_EXECUTE));
-    }
-
 }


### PR DESCRIPTION
In this PR I'm reverting changes related to the addition of `permissions` config attribute. It was added only as a mechanism to provide non default permission settings for `java.nio.Files.createTempFile`. I'm switching to the usage of `java.io.File` API for temp file creation. This API doesn't mess up with permissions and encourages the usage of umask.